### PR TITLE
Add joblib for parallel ERDDAP AdvancedSearch query

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,7 @@ dependencies:
   - palettable
   - iris
   - folium
+  - joblib
   - pip
   - pip:
     - git+https://github.com/ioos/colocate.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ numpy
 palettable
 #iris
 folium
+joblib


### PR DESCRIPTION
Resolves parallelization of ERDDAP Advanced Search in #14 (non 'extra-credit' part).  

It is still prone to delay waiting for the 'last' ERDDAP to respond, as I wasn't able to figure out how to implement the 'timeout' parameter in `joblib.Parallel` ([docs](https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html))and still retrieve results from the other sub-processes.  If anyone knows how to do this, please submit another PR!

